### PR TITLE
added ability to search by author display name

### DIFF
--- a/admin/hooks.php
+++ b/admin/hooks.php
@@ -6,9 +6,11 @@ class Hooks{
 		add_action( 'save_post', array( &$this, 'save_post' ) );
 		add_action( 'delete_post', array( &$this, 'delete_post' ) );
 		add_action( 'trash_post', array( &$this, 'delete_post' ) );
+		add_action( 'personal_options_update', array( &$this, 'update_author' ) );
+		add_action( 'edit_user_profile_update', array( &$this, 'update_author' ) );
 	}
 	
-	function save_post( $post_id ) {
+	function save_post( $post_id, $display_name = null ) {
 		if(is_object( $post_id )){
 			$post = $post_id;
 		} else {
@@ -26,7 +28,7 @@ class Hooks{
 		}
 
 		if ($post->post_status == 'publish'){
-			Indexer::addOrUpdate($index, $post);
+			Indexer::addOrUpdate($index, $post, $display_name);
 		}
 	}
 
@@ -44,7 +46,28 @@ class Hooks{
 		$index = Api::index(true);
 		Indexer::delete($index, $post);
 	}
+
+	function update_author($user_id){
+		global $es_hooks;
+
+		$query = new \WP_Query("author=$user_id&posts_per_page=-1");
+		
+		if ( $query->have_posts() ) {
+			// Avoid an infinite loop
+			if(remove_action('save_post', array($es_hooks, 'save_post'))){
+
+				while ( $query->have_posts() ) {
+					$query->the_post();
+					$this->save_post(get_the_ID(), $_POST['display_name']);
+				}
+
+				// Hook the action back up
+				add_action( 'save_post', array( &$this, 'save_post' ) );
+				
+			}
+		}
+	}
 }
 
-new Hooks();
+$es_hooks = new Hooks();
 ?>

--- a/api/Defaults.php
+++ b/api/Defaults.php
@@ -3,7 +3,7 @@ namespace elasticsearch;
 
 class Defaults{
 	static function fields(){
-		return array('post_date', 'post_content', 'post_title');
+		return array('post_date', 'post_content', 'post_title', 'post_author');
 	}
 
 	static function types(){


### PR DESCRIPTION
Here's an implementation for allowing users to search by display name.
Wordpress doesn't have a great way of hooking into a display name
change, so I had to hook into edit_user_profile_update and
personal_options_update then retireve the POST var from the form. This
isn't a great way of doing things, but since those 2 hooks fire before
the author is updated it's the only way to get the new display name.
