### PR TITLE
Add a filter to change the posts_per_page when it needs to be different than the backend value

### DIFF
--- a/theme/search.php
+++ b/theme/search.php
@@ -27,6 +27,8 @@ class Search{
 			$wp_query->query_vars['posts_per_page'] = get_option('posts_per_page');
 		}
 
+		$wp_query->query_vars['posts_per_page'] = apply_filters( 'es_modify_posts_per_page', $wp_query->query_vars['posts_per_page'] );
+
 		$results = Searcher::query($search, $this->page, $wp_query->query_vars['posts_per_page'], $wp_query->query_vars);
 
 		if($results == null){


### PR DESCRIPTION
Added a filter to be able to change the posts_per_page when it needs to be different than the backend value. Right now the value was always the backend one. But it can be useful to change it, for example, if you need to set 1 post per page on the home page, but you need 10 on the search page. The little filter give us the choice to do so quickly and easily.
