### PR TITLE
Use 0 for post__in when no results are found

### DIFF
--- a/wp/theme/category.php
+++ b/wp/theme/category.php
@@ -54,7 +54,7 @@ class Category{
 		
 		$wp_query->query_vars['s'] = '';	
 		# do not show results if none were returned
-		$wp_query->query_vars['post__in'] = empty($results['ids']) ? array(-1) : $results['ids'];
+		$wp_query->query_vars['post__in'] = empty($results['ids']) ? array(0) : $results['ids'];
 		$wp_query->query_vars['paged'] = 1;
 		$wp_query->facets = $results['facets'];
 

--- a/wp/theme/search.php
+++ b/wp/theme/search.php
@@ -40,7 +40,7 @@ class Search{
 		
 		$wp_query->query_vars['s'] = '';	
 		# do not show results if none were returned
-		$wp_query->query_vars['post__in'] = empty($results['ids']) ? array(-1) : $results['ids'];
+		$wp_query->query_vars['post__in'] = empty($results['ids']) ? array(0) : $results['ids'];
 		$wp_query->query_vars['paged'] = 1;
 		$wp_query->facets = $results['facets'];
 


### PR DESCRIPTION
When no result is found, `$wp_query->query_vars['post__in']` should be set to `array(0)`. Currently, if no result is found, WordPress will load one post.

By the way, I fixed this in both search.php and category.php, but there is lots of duplication between those two files so you might want to extract the common functionality.
