### PR TITLE
Strip tags from post content

### DIFF
--- a/src/elasticsearch/Indexer.php
+++ b/src/elasticsearch/Indexer.php
@@ -190,6 +190,8 @@ class Indexer{
 			if(isset($post->$field)){
 				if($field == 'post_date'){
 					$document[$field] = date('c',strtotime($post->$field));
+				}else if($field == 'post_content'){
+					$document[$field] = strip_tags($post->$field);
 				}else{
 					$document[$field] = $post->$field;
 				}


### PR DESCRIPTION
I think it makes sense to remove all tags from post_content.

This has the following advantages:
- Smaller index
- No search results for "technical" terms such as `html`, `script`, `media`, `utf8` etc.
- When using highlights, the returned excerpts don't contain part of html tags. Currenlty, it might return sth. like `ndex.html" class="button">Some text here with the search term in it ...`.
