### PR TITLE
changed 'text' query to 'match' and added 'fuzzy' query in case no matches found.

### DIFF
--- a/src/elasticsearch/Searcher.php
+++ b/src/elasticsearch/Searcher.php
@@ -19,8 +19,8 @@ class Searcher{
 	* 
 	* @return array The results of the search
 	**/
-	public static function search($search, $pageIndex = 0, $size = 10, $facets = array()){
-		$args = self::_buildQuery($search, $facets);
+	public static function search($search, $pageIndex = 0, $size = 10, $facets = array(), $zero_result = false){
+		$args = self::_buildQuery($search, $facets, $zero_result);
 
 		if(empty($args) || (empty($args['query']) && empty($args['facets']))){
 			return array(
@@ -102,7 +102,7 @@ class Searcher{
 	/**
 	* @internal
 	**/
-	public static function _buildQuery($search, $facets = array()){
+	public static function _buildQuery($search, $facets = array(), $zero_result = false){
 		global $blog_id;
 
 		$shoulds = array();
@@ -139,10 +139,18 @@ class Searcher{
 				$score = Config::score('field', $field);
 
 				if($score > 0){
-					$shoulds[] = array('match' => array($field => array(
-						'query' => $search,
-						'boost' => $score
-					)));
+					if ($zero_result && $field == 'post_content') {
+						$shoulds[] = array('fuzzy' => array($field => array(
+							'value' => $search,
+							'boost' => $score
+						)));
+					}
+					else {
+						$shoulds[] = array('match' => array($field => array(
+							'query' => $search,
+							'boost' => $score
+						)));
+					}					
 				}
 			}
 

--- a/wp/theme/search.php
+++ b/wp/theme/search.php
@@ -31,8 +31,15 @@ class Search{
 
 		$results = Searcher::search($search, $this->page, $wp_query->query_vars['posts_per_page'], $wp_query->query_vars);
 
+		/**
+		* If the search didn't return any result, 
+		* try a 'fuzzy' query, better than showing "Nothing found!"
+		**/
 		if($results == null){
-			return null;
+			return null;			
+		}
+		if (empty($results['ids'])) {
+			$results = Searcher::search($search, $this->page, $wp_query->query_vars['posts_per_page'], $wp_query->query_vars, true);
 		}
 
 		$this->total = $results['total'];


### PR DESCRIPTION
Changed text query to match because the latter has been deprecated see http://www.elasticsearch.org/guide/reference/query-dsl/text-query/

Changed a bit in the 'search logic' as follows: if a search query didn't return any result, we try a 'fuzzy' search query on post_content.
