### PR TITLE
Update elasticsearch.php - added elasticsearch_nhp_options_section_setup...

### DIFF
--- a/elasticsearch.php
+++ b/elasticsearch.php
@@ -89,7 +89,10 @@ add_action('init', function(){
 
 	global $NHP_Options;
 
-    $tabs = array();
+    	$tabs = array();
+
+	$sections = Config::apply_filters("nhp_options_section_setup", $sections);
+	$args = Config::apply_filters("nhp_options_args_setup", $args);
 
 	$NHP_Options = new \NHP_Options($sections, $args, $tabs);
 }, 10241988);


### PR DESCRIPTION
... and elasticsearch_nhp_options_args_setup filters.

We're writing an extension to your plugin which allows us to add custom fields to the index as well as set up custom 'search widgets' on specific fields. Originally our plugin had a separate nhp options section in the back-end, but we found we could integrate with your plugin back-end interface directly by adding the filters
elasticsearch_nhp_options_section_setup
and
elasticsearch_nhp_options_args_setup
