### PR TITLE
Fix pre get posts

### DIFF
--- a/wp/theme/AbstractArchive.php
+++ b/wp/theme/AbstractArchive.php
@@ -10,7 +10,7 @@ abstract class AbstractArchive{
 	var $search = '';
 
 	function __construct(){
-		add_action('pre_get_posts', array(&$this, 'do_search'));
+		add_action('pre_get_posts', array(&$this, 'do_search'), 100);
 		add_action('the_posts', array(&$this, 'process_search'));
 	}
 


### PR DESCRIPTION
If a plugin or the developer itself uses pre_get_posts to change posts_per_page it will break pagination. Firing the action later will solve most conflicts.
