### PR TITLE
Move addSort so it is possible to override sort value in elasticsearch_searcher_query filter

### DIFF
--- a/src/elasticsearch/Searcher.php
+++ b/src/elasticsearch/Searcher.php
@@ -43,6 +43,12 @@ class Searcher{
 		$query->setSize($size);
 		$query->setFields(array('id'));
 
+		if($sortByDate){
+			$query->addSort(array('post_date' => 'desc'));
+		}else{
+			$query->addSort('_score');
+		}
+
 		Config::apply_filters('searcher_query', $query);
 
 		try{
@@ -50,12 +56,6 @@ class Searcher{
 
 			$search = new \Elastica\Search($index->getClient());
 			$search->addIndex($index);
-			
-			if($sortByDate){
-				$query->addSort(array('post_date' => 'desc'));
-			}else{
-				$query->addSort('_score');
-			}
 
 			Config::apply_filters('searcher_search', $search);
 


### PR DESCRIPTION
Move addSort so it is possible to override sort value in elasticsearch_searcher_query filter

Right now, it is impossible to sort by "_score" ascending instead of descending because the value is overriden after the searcher_query filter. By moving the addSort just before the filter, it is possible to do so.
