### PR TITLE
silence warning in category with isset check

### DIFF
--- a/wp/theme/category.php
+++ b/wp/theme/category.php
@@ -33,7 +33,7 @@ class Category{
 			$catids = explode(',', $wp_query->query_vars['cat']);
 
 			foreach($catids as $id){
-				if(!in_array($id, $enabled)){
+				if(isset($enabled) && !in_array($id, $enabled)){
 					return;
 				}
 


### PR DESCRIPTION
Dead simple. Silences the "PHP Warning:  in_array() expects parameter 2 to be array, null given" that this plugin was writing to my logs on every pageload by checking if $enabled exists before trying to use it.
