### PR TITLE
add missing usage of the apply_filters results on searcher_query and sea...

### DIFF
--- a/src/elasticsearch/Searcher.php
+++ b/src/elasticsearch/Searcher.php
@@ -44,7 +44,7 @@ class Searcher{
 		$query->setSize($size);
 		$query->setFields(array('id'));
 
-		Config::apply_filters('searcher_query', $query);
+		$query = Config::apply_filters('searcher_query', $query);
 
 		try{
 			$index = Indexer::_index(false);
@@ -58,7 +58,7 @@ class Searcher{
           $query->addSort('_score');
         }
       }
-			Config::apply_filters('searcher_search', $search, $query);
+			$search = Config::apply_filters('searcher_search', $search, $query);
 
 			$results = $search->search($query);
 


### PR DESCRIPTION
add missing usage of the apply_filters results on searcher_query and searcher_search.
Because this should be possible:
https://github.com/parisholley/wordpress-fantastic-elasticsearch/wiki/Wordpress-Filters
elasticsearch_searcher_query (\Elastica\Query $query) - """Modify""" elastica client query object before execution
elasticsearch_searcher_search (\Elastica\Search $query) - """Modify""" elastica client search object before execution
