### PR TITLE
Do not overwrite $wp_query with global symbol of the same name

### DIFF
--- a/wp/theme/AbstractArchive.php
+++ b/wp/theme/AbstractArchive.php
@@ -15,8 +15,6 @@ abstract class AbstractArchive{
 	}
 
 	function do_search($wp_query){
-		global $wp_query;
-
 		if(!$wp_query->is_main_query() || is_admin() || $this->attempted){
 			return;
 		}


### PR DESCRIPTION
`AbstractArchive::do_search()` accepts a `$wp_query` parameter but was immediately overwriting it by importing the global of the same name.

The problem we found this to cause was that if other plugins create a WP_Query object _before_ the main query runs, `$wp_query->is_main_query()` would naturally evaluate as true (because the test is against the _global_ `$wp_query`, not the query that's actually running).

The `attempted` flag is then set to true and, when the main query finally comes in, `do_search()` bails prematurely:

``` php
//  pre_get_posts fires and the $wp_query object comes in:
function do_search($wp_query){
    // It is immediately overwritten by a global import
    global $wp_query

    // Now we're testing to see if the global $wp_query is the main query ... it will be
    if(!$wp_query->is_main_query() || is_admin() || $this->attempted){
        return;
    }

    // This flag is set prematurely ... when the main query actually runs this method
    // will have bailed already
    $this->attempted = true;
```

This pull request simply removes the `global $wp_query` import, avoiding this issue when and if other plugins generate their own queries early in the request.
