### PR TITLE
Assign values for unassigned instance variables before referencing them....

### DIFF
--- a/wp/theme/widget-options.php
+++ b/wp/theme/widget-options.php
@@ -148,6 +148,14 @@ class FacetingOptionsWidget extends \WP_Widget {
 	}
 
 	function form( $instance ) {
+		$defaults = array(
+			'async' => false,
+			'asyncReplace' => '',
+			'cssOffset' => '',
+		);
+
+		$instance = array_merge($defaults,$instance);
+
 		?>
 			<p>  
 				<input class="checkbox" type="checkbox" <?php checked( $instance['async'], true ); ?>

--- a/wp/theme/widget-selected.php
+++ b/wp/theme/widget-selected.php
@@ -149,6 +149,13 @@ class FactingSelectedWidget extends \WP_Widget {
 	}
 
 	function form( $instance ) {
+		$defaults = array(
+			'async' => false,
+			'showEmpty' => false,
+			'splitSpaces' => false,
+		);
+
+		$instance = array_merge($defaults,$instance);
 		?>
 			<p>  
 				<input class="checkbox" type="checkbox" <?php checked( $instance['async'], true ); ?>


### PR DESCRIPTION
When developing a new site for which i want to use elastichsearch, I installed the plugin. But when i drag the facetted search widgets on a siderbar it threw up errors. So this patch should fix that issue by assigning default values before trying to get their values.
