### PR TITLE
Allow filtering of Index::get_count() query args

### DIFF
--- a/src/elasticsearch/Indexer.php
+++ b/src/elasticsearch/Indexer.php
@@ -42,10 +42,10 @@ class Indexer{
 	* @return integer number of posts
 	**/
 	static function get_count(){
-		$query = new \WP_Query(array(
+		$query = new \WP_Query(Config::apply_filters('indexer_count_posts', array(
 			'post_type' => Config::types(),
 			'post_status' => 'publish'
-		));
+		)));
 
 		return $query->found_posts; //performance risk?
 	}


### PR DESCRIPTION
The query args in `elasticsearch\Indexer::get_posts()` are filterable which is awesome and really adds to the flexibility of the plugin.

Unfortunately, if we modify the arguments via `elasticsearch_indexer_get_posts` then the total number of posts we are going to index is generally going to be out-of-sync with the total reported by the `get_count()` method (same class).

This PR simply adds a new filter hook - `elasticsearch_indexer_count_posts` - to compliment the existing hook within `get_posts()`.

To provide a real life example,  we've got various custom post statuses for our forum content and need to index more than just those topics/replies that have a status of _publish_ - it would round things off nicely to have this extra hook in place to help with that goal.
