### PR TITLE
Feature/filter standard fields

### DIFF
--- a/src/elasticsearch/Defaults.php
+++ b/src/elasticsearch/Defaults.php
@@ -16,7 +16,7 @@ class Defaults{
 	**/
 	static function fields(){
 		$fields = array('post_content', 'post_title', 'post_type');
-        return Config::apply_filters('post_fields', $fields);
+        	return Config::apply_filters('post_fields', $fields);
 	}
 
 	/**


### PR DESCRIPTION
Added filter to Defaults::fields()

This makes it possible to add extra fields that are accessible as public properties via the
WP_Post class. Providing countless possibilities if one were to extend the WP_Post class. Based on the clever idea from @jmslbam.
