### PR TITLE
Fixed counter reset to zero after completion.

### DIFF
--- a/wp/admin/sections/manage-index.js
+++ b/wp/admin/sections/manage-index.js
@@ -6,7 +6,7 @@
 		if(failed){
 			$('#error').show().find('.msg').text(failed);
 		}else{
-            $('.finished').text(0);
+            		$('.finished').text(0);
 			$('#complete').show();
 		}
 	}


### PR DESCRIPTION
When you reindexed two times right after eachother the count
was not correct: i.e. for 2500 posts the counter would read:
2501 of 2500, cause no reset to zero was present.
