### PR TITLE
Allow users to set extra client options when needed (logging for example)

### DIFF
--- a/src/elasticsearch/Indexer.php
+++ b/src/elasticsearch/Indexer.php
@@ -315,6 +315,9 @@ class Indexer{
 			$settings['timeout'] = Config::option('server_timeout_read') ?: 1;
 		}
 
+      // Allow custom settings to be passed by users who want to.
+      $settings = apply_filters('indexer_client_settings',$settings);
+
 		return new \Elastica\Client($settings);
 	}
 


### PR DESCRIPTION
I had/have some problems with getting my environment to work with elasticsearch, and one of the latest problems i had was that for some reason elastica returns that all shards have failed, while all shards are in fact green.

So I wanted to enable logging on elastica (i know this requires the psr/log package, but i handle this in my own composer.json). To do so now, would require changing the plugin, which i rather not, so I thought i'd submit this filter addition
