### PR TITLE
Removes post document from index when unpublished.

### DIFF
--- a/wp/admin/hooks.php
+++ b/wp/admin/hooks.php
@@ -6,8 +6,15 @@ class Hooks{
 		add_action( 'save_post', array( &$this, 'save_post' ) );
 		add_action( 'delete_post', array( &$this, 'delete_post' ) );
 		add_action( 'trash_post', array( &$this, 'delete_post' ) );
+		add_action( 'transition_post_status', array( &$this, 'unpublish' ), 10, 3 );
 	}
-	
+
+	function unpublish($new_status, $old_status, $post) {
+		if ($old_status == 'publish' && $new_status != 'publish') {
+			$this->delete_post($post);
+		}
+	}
+
 	function save_post( $post_id ) {
 		if(is_object( $post_id )){
 			$post = $post_id;


### PR DESCRIPTION
Posts that have transitioned from `publish` to some other status should be removed from the index, preventing them from appearing in search results, etc.