### PR TITLE
Convert search criteria into a filter

### DIFF
--- a/wp/theme/AbstractArchive.php
+++ b/wp/theme/AbstractArchive.php
@@ -22,10 +22,6 @@ abstract class AbstractArchive{
 			return;
 		}
 
-		if ( !isset($wp_query->query) || empty($wp_query->query_vars)) {
-			return;
-		}
-
 		$this->attempted = true;
 
 		$args = $this->facets($wp_query, isset($_GET['es']) ? $_GET['es'] : array());


### PR DESCRIPTION
I ran into a problem with my site, which after a couple of hours searching i tracked down to how this plugin worked in combination with another plugin. It appears the other plugin (which i will ask for a fix as well), does some queries in the pre_get_posts, which screws up this plugin.

Basically what happens is that a plugin does some queries in the pre_get_posts to determine if it should do something. These queries do appear to be the main_query, even though they are not. I guess you ran into somewhat similair problems (looking at the attempted variable).

So to allow other people with similair problems to correct this i introduced this filter. Basically you will get one filter per search type. So you should get:

* elasticsearch_should_query_search
* elasticsearch_should_query_tag
* elasticsearch_should_query_archive
* elasticsearch_should_query_taxonomy
* elasticsearch_should_query_search
* elasticsearch_should_query_category

People can then add their own criteria (or remove the default ones) when needed.

If you have some alternative solution i could not think of, which will not require this pull request, please let me know!